### PR TITLE
Extending the stream function to allow clients to specify execution options

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -2,15 +2,11 @@
 
 This document describes how to set up your development environment and run TypeORM test cases.
 
-- [Building and Testing TypeORM](#building-and-testing-typeorm)
-  - [Prerequisite Software](#prerequisite-software)
-  - [Getting the Sources](#getting-the-sources)
-  - [Installing NPM Modules](#installing-npm-modules)
-  - [ORM config](#orm-config)
-  - [Building](#building)
-  - [Running Tests Locally](#running-tests-locally)
-    - [Faster developer cycle for editing code and running tests](#faster-developer-cycle-for-editing-code-and-running-tests)
-  - [Using Docker](#using-docker)
+* [Prerequisite Software](#prerequisite-software)
+* [Getting the Sources](#getting-the-sources)
+* [Installing NPM Modules](#installing-npm-modules)
+* [Building](#building)
+* [Running Tests Locally](#running-tests-locally)
 
 See the [contribution guidelines](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
 if you'd like to contribute to TypeORM.
@@ -23,7 +19,7 @@ following products on your development machine:
 * [Git](http://git-scm.com) and/or the **GitHub app** (for [Mac](http://mac.github.com) or
   [Windows](http://windows.github.com)); [GitHub's Guide to Installing
   Git](https://help.github.com/articles/set-up-git) is a good source of information.
-* [Node.js](http://nodejs.org), (use version 16.20.0) which is used to run a development web server,
+* [Node.js](http://nodejs.org), (use 16.20.0) which is used to run a development web server,
   run tests, and generate distributable files.
   Depending on your system, you can install Node either from source or as a pre-packaged bundle.
 * [Mysql](https://www.mysql.com/) is required to run tests on this platform (or docker)
@@ -85,6 +81,7 @@ You can link (or simply copy/paste) this directory into your project and test Ty
 To build the distribution package of TypeORM packed into a `.tgz`, run:
 
 ```shell
+nvm use 16.20.0
 npm run pack
 ```
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -2,11 +2,15 @@
 
 This document describes how to set up your development environment and run TypeORM test cases.
 
-* [Prerequisite Software](#prerequisite-software)
-* [Getting the Sources](#getting-the-sources)
-* [Installing NPM Modules](#installing-npm-modules)
-* [Building](#building)
-* [Running Tests Locally](#running-tests-locally)
+- [Building and Testing TypeORM](#building-and-testing-typeorm)
+  - [Prerequisite Software](#prerequisite-software)
+  - [Getting the Sources](#getting-the-sources)
+  - [Installing NPM Modules](#installing-npm-modules)
+  - [ORM config](#orm-config)
+  - [Building](#building)
+  - [Running Tests Locally](#running-tests-locally)
+    - [Faster developer cycle for editing code and running tests](#faster-developer-cycle-for-editing-code-and-running-tests)
+  - [Using Docker](#using-docker)
 
 See the [contribution guidelines](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
 if you'd like to contribute to TypeORM.
@@ -19,7 +23,7 @@ following products on your development machine:
 * [Git](http://git-scm.com) and/or the **GitHub app** (for [Mac](http://mac.github.com) or
   [Windows](http://windows.github.com)); [GitHub's Guide to Installing
   Git](https://help.github.com/articles/set-up-git) is a good source of information.
-* [Node.js](http://nodejs.org), (better to install latest version) which is used to run a development web server,
+* [Node.js](http://nodejs.org), (use version 16.20.0) which is used to run a development web server,
   run tests, and generate distributable files.
   Depending on your system, you can install Node either from source or as a pre-packaged bundle.
 * [Mysql](https://www.mysql.com/) is required to run tests on this platform (or docker)
@@ -54,6 +58,7 @@ git remote add upstream https://github.com/typeorm/typeorm.git
 Install all TypeORM dependencies by running this command:
 
 ```shell
+nvm use 16.20.0
 npm install
 ```
 

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -316,14 +316,19 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
         parameters?: any[],
         onEnd?: Function,
         onError?: Function,
+        executionOptions?: any,
     ): Promise<ReadStream> {
         if (this.isReleased) {
             throw new QueryRunnerAlreadyReleasedError()
         }
 
-        const executionOptions = {
+        const currentExecutionOptions = {
             autoCommit: !this.isTransactionActive,
             outFormat: this.driver.oracle.OUT_FORMAT_OBJECT,
+        }
+
+        if (executionOptions) {
+            Object.assign(currentExecutionOptions, executionOptions)
         }
 
         const databaseConnection = await this.connect()
@@ -334,7 +339,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
             const stream = databaseConnection.queryStream(
                 query,
                 parameters,
-                executionOptions,
+                currentExecutionOptions,
             )
             if (onEnd) {
                 stream.on("end", onEnd)

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1905,7 +1905,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
     /**
      * Executes built SQL query and returns raw data stream.
      */
-    async stream(): Promise<ReadStream> {
+    async stream(executionOptions?: any): Promise<ReadStream> {
         this.expressionMap.queryEntity = false
         const [sql, parameters] = this.getQueryAndParameters()
         const queryRunner = this.obtainQueryRunner()
@@ -1931,6 +1931,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                 parameters,
                 releaseFn,
                 releaseFn,
+                executionOptions,
             )
 
             // close transaction if we started it

--- a/src/query-runner/QueryRunner.ts
+++ b/src/query-runner/QueryRunner.ts
@@ -134,6 +134,7 @@ export interface QueryRunner {
         parameters?: any[],
         onEnd?: Function,
         onError?: Function,
+        executionOptions?: any,
     ): Promise<ReadStream>
 
     /**


### PR DESCRIPTION
- Extending the `stream` function to allow clients to specify options for executed queries
  - Overrides the default oracle execution options that TypeORM already provides
- Adding node version in the developer documentation